### PR TITLE
Smoke testing  when updating dependencies (and doing PR's)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - deps/**
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.0.0
+
+      - name: Install dependencies
+        run: uv sync --frozen --group dev
+        working-directory: .
+
+      - name: Run smoke tests
+        run: uv run pytest -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   test:
+    # Skip pull_request runs for deps/* branches — those are covered by the push trigger.
+    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'deps/')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -2,7 +2,7 @@ name: Update dependencies
 
 on:
   schedule:
-    - cron: "0 6 * * 1"  # Every Monday at 06:00 UTC
+    - cron: "0 6 * * 1" # Every Monday at 06:00 UTC
   workflow_dispatch:
 
 jobs:
@@ -14,19 +14,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.0.0
 
       - name: Update lock file
         run: uv lock --upgrade
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
-          commit-message: "chore: update pinned dependencies"
-          title: "chore: update pinned dependencies"
+          commit-message: "chore: update pinned Python dependencies"
+          title: "chore: update pinned Python dependencies"
           body: "Automated weekly dependency update via `uv lock --upgrade`."
           branch: deps/update-uv-lock
           delete-branch: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["pytest>=8"]
+dev = ["pytest>=8,<10"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,9 @@ dependencies = [
     "async-lru",
     "prometheus-fastapi-instrumentator",
 ]
+
+[dependency-groups]
+dev = ["pytest>=8"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+import json
+import os
+
+# Must be set before any app module is imported, since config is cached at import time.
+os.environ.setdefault(
+    "SCOUTNET_PROJECTS",
+    json.dumps([{"id": 1, "name": "Test Project", "member_key": "mk1", "question_key": "qk1"}]),
+)
+os.environ.setdefault("AUTH_DISABLED", "true")
+os.environ.setdefault("PERSIST_DIR", "/tmp/j26-signupinfo-test")
+
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock, patch
+
+
+@pytest.fixture(scope="session")
+def client():
+    # Patch scoutnet_init/shutdown so tests don't hit external services.
+    # The names are patched in the main module where they were imported.
+    with (
+        patch("pyapp.app.main.scoutnet_init", new_callable=AsyncMock),
+        patch("pyapp.app.main.scoutnet_shutdown", new_callable=AsyncMock),
+    ):
+        from pyapp.app.main import app
+
+        with TestClient(app) as c:
+            yield c

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,12 @@ import json
 import os
 
 # Must be set before any app module is imported, since config is cached at import time.
-os.environ.setdefault(
-    "SCOUTNET_PROJECTS",
-    json.dumps([{"id": 1, "name": "Test Project", "member_key": "mk1", "question_key": "qk1"}]),
+# Use explicit assignment (not setdefault) so these always take effect regardless of the environment.
+os.environ["SCOUTNET_PROJECTS"] = json.dumps(
+    [{"id": 1, "name": "Test Project", "member_key": "mk1", "question_key": "qk1"}]
 )
-os.environ.setdefault("AUTH_DISABLED", "true")
-os.environ.setdefault("PERSIST_DIR", "/tmp/j26-signupinfo-test")
+os.environ["AUTH_DISABLED"] = "true"
+os.environ["PERSIST_DIR"] = "/tmp/j26-signupinfo-test"
 
 import pytest
 from fastapi.testclient import TestClient

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,38 @@
+"""
+Smoke tests for dependency update PRs.
+
+These verify that the app boots and key endpoints respond correctly with new
+dependencies. External services (Scoutnet, Keycloak) are mocked out.
+"""
+
+
+def test_app_boots(client):
+    """TestClient lifespan startup succeeded if we get here."""
+    pass
+
+
+def test_metrics(client):
+    r = client.get("/metrics")
+    assert r.status_code == 200
+    assert b"http_requests_total" in r.content
+
+
+def test_app_config(client):
+    r = client.get("/app-config")
+    assert r.status_code == 200
+    data = r.json()
+    assert "navigation" in data
+    assert len(data["navigation"]) > 0
+
+
+def test_swagger_docs(client):
+    r = client.get("/api/docs")
+    assert r.status_code == 200
+
+
+def test_openapi_schema(client):
+    r = client.get("/api/openapi.json")
+    assert r.status_code == 200
+    schema = r.json()
+    assert "paths" in schema
+    assert "info" in schema

--- a/uv.lock
+++ b/uv.lock
@@ -460,6 +460,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -481,6 +490,11 @@ dependencies = [
     { name = "prometheus-fastapi-instrumentator" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "async-lru" },
@@ -490,6 +504,9 @@ requires-dist = [
     { name = "joserfc" },
     { name = "prometheus-fastapi-instrumentator" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8" }]
 
 [[package]]
 name = "jinja2"
@@ -597,6 +614,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -755,6 +790,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
A summary of what is added:

**New files:**
- `tests/conftest.py` — Sets env vars before any app imports, provides a session-scoped `TestClient` fixture with `scoutnet_init`/`scoutnet_shutdown` mocked
- `tests/test_smoke.py` — 5 smoke tests: app boots, `/metrics`, `/app-config`, `/api/docs`, `/api/openapi.json`
- `.github/workflows/ci.yml` — CI workflow triggered on pushes to `deps/**` and PRs to `main`

**Modified files:**
- `pyproject.toml` — Added `[dependency-groups] dev = ["pytest>=8"]` and `[tool.pytest.ini_options]`

**How it fits together:** `create-pull-request` pushes to the `deps/update-uv-lock` branch before creating the PR. That push triggers `ci.yml` (via the `push: deps/**` trigger), so CI results appear on the PR before you merge.
