### PR TITLE
fix: merge form sections of the same type instead of overwriting

### DIFF
--- a/pyapp/app/scoutnet.py
+++ b/pyapp/app/scoutnet.py
@@ -238,7 +238,11 @@ async def _get_all_projectdata_from_scoutnet() -> list[ScoutnetProjectData]:
 
         questions = {"sections": {}, "questions": {}}
         for forms_data in form_results:
-            questions["sections"][forms_data["form"]["type"]] = forms_data["sections"]
+            # Merge (don't overwrite) sections: a project can have multiple forms
+            # sharing the same form type (e.g. two "individual" forms). Overwriting
+            # would drop one form's sections while its questions still get merged in
+            # below, leaving questions pointing at missing sections (KeyError on decode).
+            questions["sections"].setdefault(forms_data["form"]["type"], {}).update(forms_data["sections"])
             questions["questions"].update(forms_data["questions"])
 
         return ScoutnetProjectData(


### PR DESCRIPTION
## What happened

The app crashed on startup with `KeyError: 21369` (`Application startup failed. Exiting.`) — with no deploy. It's a data change on the Scoutnet side.

Project 52716 now serves **two forms that both report `form.type = "individual"`** (forms 43853 and 43854).

## Root cause

When fetching a project's forms, sections were keyed by form *type* and **overwritten** per form, while all forms' questions were merged together:

```python
questions["sections"][forms_data["form"]["type"]] = forms_data["sections"]  # overwrite
questions["questions"].update(forms_data["questions"])                      # merge
```

Two forms sharing the same type meant one form's sections clobbered the other's, while both forms' questions survived. That orphaned question 88235 → its section 21369 no longer existed in the section lookup → `KeyError` during cache decode. Since the decode runs in the FastAPI `lifespan`, this took down the whole app at startup.

Hiding/unhiding the section's questions did not help, because the section wasn't missing due to being hidden — it was being clobbered by a same-typed sibling form.

## Fix

Merge sections of the same form type instead of overwriting. Verified the two forms' section IDs are disjoint, so the merge loses nothing.

## Follow-up (not in this PR)

Consider a defensive guard in the decoder so an orphaned question logs a warning and is skipped rather than crashing the whole app at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)